### PR TITLE
Feat: add choice page after login - profile and chatting

### DIFF
--- a/srcs/frontend/src/App.js
+++ b/srcs/frontend/src/App.js
@@ -1,8 +1,8 @@
-import logo from './logo.svg';
 import './App.css';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ChakraProvider } from '@chakra-ui/react';
 import MainPage from './components/pages/MainPage';
+import ChoicePage from './components/pages/ChoicePage';
 
 function App() {
   return (
@@ -10,6 +10,7 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route index element={<MainPage />} />
+          <Route path="choice" element={<ChoicePage />} />
         </Routes>
       </BrowserRouter>
     </ChakraProvider>

--- a/srcs/frontend/src/components/login/ChoiceBox.jsx
+++ b/srcs/frontend/src/components/login/ChoiceBox.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Box } from '@chakra-ui/layout';
+
+/**
+ * 로그인에 성공하면 나오는 페이지에서 사용하는 프로필/채팅 컴포넌트
+ * 
+ * @param title : 박스 텍스트
+ * @param onClick : 클릭 시 발생하는 이벤트
+ * @returns 
+ */
+function ChoiceBox(props) {
+	const { title, onClick } = props;
+
+	return <Box
+			as='button'
+			bg='white'
+			color='black'
+			h='sm'
+			fontSize={'5xl'}
+			onClick={onClick}
+			>
+				{title}
+			</Box>
+}
+
+export default ChoiceBox;

--- a/srcs/frontend/src/components/pages/ChoicePage.jsx
+++ b/srcs/frontend/src/components/pages/ChoicePage.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import { Divider } from '@chakra-ui/react'
+import ChoiceBox from "../login/ChoiceBox";
+
+/**
+ * 선택 페이지에서 프로필/채팅 버튼(박스)을 함께 가지고 있는 스타일 태그
+ */
+const Wrapper = styled.div`
+	padding: 16px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+`;
+
+/**
+ * 로그인에 성공하면 나오는 프로필/채팅 선택 페이지
+ * 
+ * @param {*} props 
+ * @returns 프로필/채팅 버튼을 묶고 있는 Wrapper
+ */
+function ChoicePage(props) {
+	const {} = props;
+
+	const navigate = useNavigate();
+
+	return (
+		<Wrapper>
+			<ChoiceBox
+				title="Profile"
+				onClick={() => {
+					navigate("/choice");
+					console.log("프로필 선택");
+				}}
+			/>
+			<Divider borderColor="black" borderWidth="1px" />
+			<ChoiceBox
+				title="Chatting"
+				onClick={() => {
+					navigate("/choice");
+					console.log("채팅 선택");
+				}}
+			/>
+		</Wrapper>
+	);
+}
+
+export default ChoicePage;

--- a/srcs/frontend/src/components/pages/MainPage.jsx
+++ b/srcs/frontend/src/components/pages/MainPage.jsx
@@ -32,7 +32,7 @@ function MainPage(props) {
 			<LoginButton
 				title="Login"
 				onClick={() => {
-					navigate("/");
+					navigate("/choice");
 					console.log("login success");
 				}}
 			/>


### PR DESCRIPTION
1. 로그인에 성공하면 나오는 프로필/채팅 선택하는 페이지를 만들었습니다.
2. 일단 로그인 버튼을 누르면 프로필/채팅 선택하는 페이지로 이동하고, 프로필이나 채팅을 선택하면 페이지는 이동하지 않게 해놨습니다.
3. 각 버튼을 눌렀을 때 console에 "프로필 선택" / "채팅 선택"이 출력되게 해놨습니다.