### PR TITLE
Feat: add intra_id column to user table

### DIFF
--- a/srcs/backend/src/user/user.entity.ts
+++ b/srcs/backend/src/user/user.entity.ts
@@ -1,10 +1,13 @@
 import { BaseEntity, Column, Entity, JoinColumn, PrimaryGeneratedColumn, Unique } from "typeorm";
 
 @Entity()
-@Unique(['nickname'])
+@Unique(['intra_id', 'nickname', 'email'])
 export class User extends BaseEntity {
 	@PrimaryGeneratedColumn()
 	id: number;
+
+	@Column()
+	intra_id: string;
 
 	@Column({ type: "varchar", length: 20 })
 	nickname: string;


### PR DESCRIPTION
1. user 테이블에 intra_id 컬럼을 추가했습니다.
타입은 string이고, 중복값이 들어오지 않게 했습니다.
유저가 닉네임을 바꾸고 나중에 다시 로그인을 할 때, 받아온 인트라 유저 정보가 user 테이블에 존재하는지(로그인을 한 적이 있는지)를 확인하기 위해 추가했습니다.
2. 2차 인증을 위해 사용하는 email 컬럼도 중복값이 들어오지 않게 수정했습니다.