### PR TITLE
Done: connect db container using docker-compose

### DIFF
--- a/srcs/.env
+++ b/srcs/.env
@@ -1,5 +1,4 @@
 # postgre_sql
-POSTGRES_HOST=localhost
 POSTGRES_DB=pong
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres

--- a/srcs/backend/.dockerignore
+++ b/srcs/backend/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/srcs/backend/Dockerfile
+++ b/srcs/backend/Dockerfile
@@ -2,6 +2,5 @@ FROM node:16-alpine3.14
 
 WORKDIR	/usr/app
 COPY	. .
-RUN		yarn install
-RUN		yarn run build
-CMD		[ "yarn", "start:dev" ]
+RUN		npm install && npm run build
+CMD		[ "npm", "run", "start:dev" ]

--- a/srcs/backend/src/configs/typeorm.config.ts
+++ b/srcs/backend/src/configs/typeorm.config.ts
@@ -5,11 +5,11 @@ const dbConfig = config.get('db');
 
 export const typeORMConfig: TypeOrmModuleOptions = {
 	type: dbConfig.type,
-	host: process.env.RDS_HOSTNAME || dbConfig.host,
-	port: process.env.RDS_PORT || dbConfig.port,
-	username:process.env.RDS_USERNAME || dbConfig.username,
-	password: process.env.RDS_PASSWORD || dbConfig.password,
-	database: process.env.RDS_DB_NAME || dbConfig.database,
+	host: dbConfig.host,
+	port: dbConfig.port,
+	username: dbConfig.username,
+	password: dbConfig.password,
+	database: dbConfig.database,
 	entities: [__dirname + '/../**/*.entity.{js,ts}'],
 	synchronize: dbConfig.synchronize,
 }

--- a/srcs/frontend/.dockerignore
+++ b/srcs/frontend/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/srcs/frontend/Dockerfile
+++ b/srcs/frontend/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /usr/app
 
 COPY	. .
 
-RUN		npm install && npm i socket.io-client
-RUN		npm run build
+RUN		npm install && npm i socket.io-client && npm run build
 
 CMD		[ "npm", "start" ]


### PR DESCRIPTION
1. docker를 이용해 프론트와 백과 디비를 연동하는 과정에서 디비 연동이 안 되는 문제를 해결함.
2. 디비 연결 호스트를 `localhost`가 아닌 `db`로 바꿈.
3. `.dockerignore` 파일에 필요없는 `node_modules` 폴더를 추가함.