### PR TITLE
Fix: modify accessToken expire time to 3 hours

### DIFF
--- a/srcs/backend/src/auth/auth.controller.ts
+++ b/srcs/backend/src/auth/auth.controller.ts
@@ -47,7 +47,7 @@ export class AuthController {
 		// 토큰 생성
 		const accessToken = await this.jwtService.sign(payload);
 		// accessToken을 cookie에 저장함
-		res.cookie('token', accessToken);
+		res.cookie('accessToken', accessToken);
 		res.cookie('intra_id', intra_id);
 		// 후에 프론트 choice 페이지로 redirect
 		res.status(302).redirect('http://localhost:3000/choice');

--- a/srcs/backend/src/auth/auth.module.ts
+++ b/srcs/backend/src/auth/auth.module.ts
@@ -16,7 +16,7 @@ const jwtConfig = config.get('jwt');
     JwtModule.register({
       secret: jwtConfig.secret,
       signOptions: {
-        expiresIn: 3600,
+        expiresIn: 3600 * 3,
       }
     }),
     TypeOrmExModule.forCustomRepository([UserRepository])


### PR DESCRIPTION
1. `accessToken` 만료 시간을 1시간에서 3시간으로 수정함.
2. `auth.controller` 파일에서 쿠키에 저장되는 토큰 변수명을 `token`에서 `accessToken`으로 변경함.